### PR TITLE
Update gd_interpolation.c

### DIFF
--- a/src/gd_interpolation.c
+++ b/src/gd_interpolation.c
@@ -1087,7 +1087,7 @@ gdImageScaleTwoPass(const gdImagePtr src, const unsigned int new_width,
     }/* if */
 
     if (src != tmp_im) {
-        gdFree(tmp_im);
+        gdImageDestroy(tmp_im);
     }/* if */
 
 	return dst;


### PR DESCRIPTION
Fixing memory leak in gdImageScaleTwoPass.
https://github.com/libgd/libgd/issues/173
